### PR TITLE
Added possibility to limit the width of bars

### DIFF
--- a/Sources/FLCharts/Models/Configurations/FLBarConfig.swift
+++ b/Sources/FLCharts/Models/Configurations/FLBarConfig.swift
@@ -27,7 +27,7 @@ public struct FLBarConfig {
     public var radius: Radius
 
     /// The width of the bar.
-    /// - note: This value will be used as absolute value if ``FLBarPlotView/shouldScroll`` is set to `true`. Else the width of the bar will be calculated based on the width of the chart but will not be larger than this value
+    /// - note: If ``FLBarPlotView/shouldScroll`` is set to `true` this value will be used as absolute value for the bar width. Else the width of the bar will be calculated based on the width of the chart but If ``limitWidth`` is set to `true` this value will be used as the maximum width for the bar
     public var width: CGFloat
     
     /// The space between each chart bar.

--- a/Sources/FLCharts/Models/Configurations/FLBarConfig.swift
+++ b/Sources/FLCharts/Models/Configurations/FLBarConfig.swift
@@ -27,17 +27,22 @@ public struct FLBarConfig {
     public var radius: Radius
 
     /// The width of the bar.
-    /// - note: This value will be used only if ``FLBarPlotView/shouldScroll`` is set to `true`. Else the width of the bar will be calculated based on the width of the chart.
+    /// - note: This value will be used as absolute value if ``FLBarPlotView/shouldScroll`` is set to `true`. Else the width of the bar will be calculated based on the width of the chart but will not be larger than this value
     public var width: CGFloat
     
     /// The space between each chart bar.
     public var spacing: CGFloat
-
+    
+    /// Limits the with of the bar if ``FLBarPlotView/shouldScroll`` is set to `false`
+    public var limitWidth: Bool
+    
     public init(radius: Radius = .corners(corners: [.layerMinXMinYCorner, .layerMaxXMinYCorner], 3),
-                width: CGFloat = 12,
-                spacing: CGFloat = 5) {
+                width: CGFloat = 25,
+                spacing: CGFloat = 5,
+                limitWidth: Bool = false) {
         self.radius = radius
         self.width = width
         self.spacing = spacing
+        self.limitWidth = limitWidth
     }
 }

--- a/Sources/FLCharts/Models/Configurations/FLBarConfig.swift
+++ b/Sources/FLCharts/Models/Configurations/FLBarConfig.swift
@@ -37,7 +37,7 @@ public struct FLBarConfig {
     public var limitWidth: Bool
     
     public init(radius: Radius = .corners(corners: [.layerMinXMinYCorner, .layerMaxXMinYCorner], 3),
-                width: CGFloat = 25,
+                width: CGFloat = 12,
                 spacing: CGFloat = 5,
                 limitWidth: Bool = false) {
         self.radius = radius

--- a/Sources/FLCharts/PlotView/FLBarPlotView.swift
+++ b/Sources/FLCharts/PlotView/FLBarPlotView.swift
@@ -129,7 +129,10 @@ extension FLBarPlotView: UICollectionViewDelegateFlowLayout {
             return CGSize(width: cellWidth, height: collectionView.frame.height)
         } else {
             let numberOfBars = CGFloat(chartData.dataEntries.count)
-            let cellWidth = collectionView.frame.width / numberOfBars
+            var cellWidth = collectionView.frame.width / numberOfBars
+            if barConfig.limitWidth {
+                cellWidth = min(cellWidth, barConfig.width)
+            }
             return CGSize(width: cellWidth, height: collectionView.frame.height)
         }
     }


### PR DESCRIPTION
If a bar chart has a small amount of bars and scrolling is disabled the bars get very big. Currently the bars have to fill the total width of the chart.
See this example:
<img width="341" alt="Screenshot BarChart" src="https://user-images.githubusercontent.com/24368986/166947279-77542ba9-7fd1-4c08-ba09-be9e7c23578f.png">

With my adjustments in this pull request the default behaviour stays the same. But you can configure to limit the width of the bars to get a result like this:
<img width="325" alt="Screenshot BarChart1" src="https://user-images.githubusercontent.com/24368986/166948263-056c3fac-9b0a-494d-95f2-dcb6bd862d21.png">