### PR TITLE
Fixed Y granularity that caused issues when updating the chart data

### DIFF
--- a/Sources/FLCharts/FLCartesianPlane.swift
+++ b/Sources/FLCharts/FLCartesianPlane.swift
@@ -408,9 +408,8 @@ public class FLCartesianPlane: UIView, FLStylable {
     }
     
     private func updateConfigGranularityY() {
-        if config.granularityY == 0 {
             config.granularityY = chartData.defaultYGranularity(forType: chartType, horizontalRepresentedValues: horizontalRepresentedValues)
-        }
+    
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
<img width="409" alt="Screen Shot 2022-07-22 at 5 41 30 AM" src="https://user-images.githubusercontent.com/29472333/180441320-f6f16f56-be65-4ddc-8747-0db890a0e1db.png">

fixed an error when updating chart data that would cause mis-sizing, causing wrong y-axis labels due to keeping the old granularity from previous data. I was going to include a check to make sure the granularity is different, but after extensive testing it seemed that there was no issues when providing no granularity, since the default is 0.